### PR TITLE
* Added support for Raspberry Pi on aarch64 (And possibly others)

### DIFF
--- a/sensors.js
+++ b/sensors.js
@@ -54,6 +54,17 @@ function sensors_output(data) {
 					var row = table.insertRow(-1);
 					row.innerHTML = "<td></td><td>Current</td><td>Max.</td><td>Crit.</td>";
 				}	
+                        } else if (lines[i].startsWith('cpu_thermal-virtual-0')) {
+                                current_adaptor = 'temp' + current_cpu;
+                                if (init == false) {
+                                        var row = table.insertRow(-1);
+                                        var header = document.createElement("TH");
+                                        header.innerHTML = current_adaptor;
+                                        header.colSpan = "4";
+                                        row.append(header);
+                                        var row = table.insertRow(-1);
+                                        row.innerHTML = "<td></td><td>Current</td><td>Max.</td><td>Crit.</td>";
+                                }
 			} 
 		} else if (lines[i] == '') {
 			current_adaptor = null;


### PR DESCRIPTION
Hello!

I've added support for cpu_thermal-virtual allowing my Raspberry Pi3 to have sensors monitored over Cockpit. 

```
leonardo@stargate:~$ sudo dmidecode -t 1
# dmidecode 3.2
Getting SMBIOS data from sysfs.
SMBIOS 3.0 present.

Handle 0x0001, DMI type 1, 27 bytes
System Information
        Manufacturer: raspberrypi
        Product Name: rpi
        Version: Not Specified
        Serial Number: 0000000095236d38
        UUID: 30303030-3030-3030-3935-323336643338
        Wake-up Type: Reserved
        SKU Number: Not Specified
        Family: Not Specified

leonardo@stargate:~$ sensors
cpu_thermal-virtual-0
Adapter: Virtual device
temp1:        +41.3°C  (crit = +80.0°C)

rpi_volt-isa-0000
Adapter: ISA adapter
in0:              N/A  

leonardo@stargate:~$ 
```

![Captura de tela de 2019-10-01 10-54-33](https://user-images.githubusercontent.com/201189/65968975-637ec800-e43a-11e9-8698-1f2a12ff8db7.png)


Its possible to merge? There is anything I need to do to allow merging?

Thanks!